### PR TITLE
liboemcrypto disabler - Update for Magisk v21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A consequence of using this module is that Widevine DRM will fall back to using 
 
 2020-10-23: v1.5
 
-- Updated for Magisk v21 template format.
+- Updated for Magisk v21.0 template format.
 
 2019-03-29: v1.4
 
@@ -52,5 +52,6 @@ A consequence of using this module is that Widevine DRM will fall back to using 
 
 - The module has been verified working on a multitude of devices, including a Samsung Galaxy S9+ (SM-G965F/DS) running Magisk 16.x/17.x on a variery of ROMs, a Samsung Tab S3 (SM-T820) running stock Android 8.0 and Magisk 16.x/17.x, and a Samsung Tab S4 (SM-T830) running stock Android 8.1 and Magisk 17.x.
 
+- The module has been verified working on a OnePlus 5 with Android 11 using Magisk v21.0.
 ## Links
 [Module's XDA forum thread](https://forum.xda-developers.com/apps/magisk/magisk-liboemcrypto-disabler-drm-t3794393)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ A consequence of using this module is that Widevine DRM will fall back to using 
 
 ## Changelog
 
+2020-10-23: v1.5
+
+- Updated for Magisk v21 template format.
+
 2019-03-29: v1.4
 
 - Updated for Magisk v19 template format.

--- a/install.sh
+++ b/install.sh
@@ -175,7 +175,10 @@ mask_lib() {
 
   # Real /system can be found here.
   #
-  local mirror=/sbin/.magisk/mirror
+
+  MAGISKPATH=$(magisk --path)
+
+  local mirror=/$MAGISKPATH/.magisk/mirror
   local so=liboemcrypto.so
 
   for part in system vendor; do

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=liboemcryptodisabler
 name=liboemcrypto disabler
-version=v1.4
-versionCode=14
-author=ianmacd
+version=v1.5
+versionCode=15
+author=ianmacd (v1.5 updated by ScRuFFy7)
 description=Disables liboemcrypto.so on rooted devices to allow DRM-protected content to play (e.g. Netflix, My5, etc.).


### PR DESCRIPTION
Update for Magisk v21.0 to support Android 11 ROMs.